### PR TITLE
Fix unknown property 'openPage'

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,7 @@ module.exports = {
   },
   devServer: {
     publicPath: '/build/',
-    open: true,
-    openPage: 'build/home.html'
+    open: ['build/home.html']
   },
   plugins: [HTMLWebpackPluginConfig]
 };


### PR DESCRIPTION
Fixes required following security and/or version updates recommended by Dependabot (up to and including PR #26).

## Changed
* Fixes issue: 
```console
[webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'openPage'.
 ```