### PR TITLE
Fix unknown property 'publicPath'

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,9 @@ module.exports = {
     path: __dirname + '/build'
   },
   devServer: {
-    publicPath: '/build/',
+    static: {
+      publicPath: '/build/',
+    },
     open: ['build/home.html']
   },
   plugins: [HTMLWebpackPluginConfig]


### PR DESCRIPTION
Fixes required following security and/or version updates recommended by Dependabot (up to and including PR #26).

## Changed
* Fixes issue: 
```console
[webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'publicPath'.
```
