### PR TITLE
Replace render with createRoot

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import { App } from './components/App.jsx';
 
-render(
-  <App />,
-  document.getElementById('app')
-);
+const container = document.getElementById('app');
+const root = createRoot(container);
+root.render(<App />);


### PR DESCRIPTION
Resolves the warning message referenced in [this comment in PR #27](https://github.com/hfagerlund/react-app-starter/pull/27#pullrequestreview-1504483569).

## Changed
* Eliminates the following warning (from the browser console at http://localhost:8080/build/home.html): 
```console
Warning: ReactDOM.render is no longer supported in React 18. 
Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. 
Learn more: https://reactjs.org/link/switch-to-createroot react-dom.development.js:86:30
```
* This uses the new root API, which creates a root running in React 18 (adds all of this version's improvements, and allows use of concurrent features).