### PR TITLE
Upgrade serialize-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "serialize-javascript": "^3.1.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3421,7 +3421,7 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -3730,6 +3730,13 @@ serialize-javascript@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
   integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
+serialize-javascript@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
+  integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
+  dependencies:
+    randombytes "^2.1.0"
 
 serve-index@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
Resolves Dependabot alert no. 4 (security update):
> Dependabot cannot update serialize-javascript to a non-vulnerable version 

> Creating a security update for serialize-javascript
> Dependabot is creating a security update to fix 1 Dependabot alert on serialize-javascript in yarn.lock.
>
> Or, manually upgrade serialize-javascript to version 3.1.0 or later. For example:
> ```
> serialize-javascript@^3.1.0:
>  version "3.1.0"
> ```
- - - -
## Prior to change:
```console
$ yarn list --pattern serialize-javascript
yarn list v1.22.5
└─ serialize-javascript@2.1.2
Done in 0.38s.
```

## Changed
```console
$ yarn upgrade serialize-javascript@^3.1.0
yarn upgrade v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
## ...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
## ...
success Saved 1 new dependency.
info Direct dependencies
└─ serialize-javascript@3.1.0
info All dependencies
└─ serialize-javascript@3.1.0
Done in 11.73s.

$ yarn list --pattern serialize-javascript
yarn list v1.22.5
├─ serialize-javascript@3.1.0
└─ terser-webpack-plugin@1.4.3
   └─ serialize-javascript@2.1.2
Done in 0.30s.

$ yarn run build
$ yarn run start
```