### PR TITLE
Upgrade json5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Heini Fagerlund",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "json5": "^1.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "semver": "^7.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2550,6 +2550,13 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+json5@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
+  dependencies:
+    minimist "^1.2.0"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"


### PR DESCRIPTION
Resolves Dependabot alert no. 51 (security update):
> Dependabot cannot update json5 to a non-vulnerable version 

> Creating a security update for json5
> Dependabot is creating a security update to fix 1 Dependabot alert on json5 in yarn.lock.
>
> Or, manually upgrade json5 to version 1.0.2 or later. For example:
> ```
> json5@^1.0.2:
>  version "1.0.2"
> ```
- - - -


## Prior to change:
```console
$ yarn list --pattern json5
yarn list v1.22.5
├─ json5@0.5.1
└─ loader-utils@1.4.2
   └─ json5@1.0.1
Done in 0.29s.
```

## Changed
```console
$ yarn upgrade json5@^1.0.2
yarn upgrade v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
## ...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 1 new dependency.
info Direct dependencies
└─ json5@1.0.2
info All dependencies
└─ json5@1.0.2
Done in 2.04s.

$ yarn list --pattern json5
yarn list v1.22.5
├─ babel-core@6.26.3
│  └─ json5@0.5.1
├─ json5@1.0.2
└─ loader-utils@1.4.2
   └─ json5@1.0.1
Done in 0.29s.

$ yarn run build
$ yarn run start
```