### PR TITLE
Upgrade glob-parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Heini Fagerlund",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "glob-parent": "^5.1.2",
     "json5": "^1.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,7 +1965,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@~5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==


### PR DESCRIPTION
Resolves Dependabot alert no. 15 (security update):
> Dependabot cannot update glob-parent to a non-vulnerable version 

> Creating a security update for glob-parent
> Dependabot is creating a security update to fix 1 Dependabot alert on glob-parent in yarn.lock.
>
> Or, manually upgrade glob-parent to version 5.1.2 or later. For example:
> ```
> glob-parent@^5.1.2:
>  version "5.1.2"
> ```
- - - -


## Prior to change:
```console
$ yarn list --pattern glob-parent
yarn list v1.22.5
├─ glob-parent@5.1.2
└─ watchpack-chokidar2@2.0.1
   └─ glob-parent@3.1.0
Done in 0.28s.
```

## Changed
```console
$ yarn upgrade glob-parent@^5.1.2
yarn upgrade v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
## ...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 0 new dependencies.
Done in 1.76s.

$ yarn list --pattern glob-parent
yarn list v1.22.5
├─ glob-parent@5.1.2
└─ watchpack-chokidar2@2.0.1
   └─ glob-parent@3.1.0
Done in 0.29s.

$ yarn run build
$ yarn run start
```